### PR TITLE
Feature/poly p additional methods

### DIFF
--- a/include/nfl/poly_p.hpp
+++ b/include/nfl/poly_p.hpp
@@ -203,8 +203,6 @@ auto SYM(nfl::ops::expr<Op, Args...> const& op0, nfl::poly_p<T, Degree, NbModuli
 
 DECLARE_BINARY_OPERATOR_P(operator-, submod)
 DECLARE_BINARY_OPERATOR_P(operator+, addmod)
-DECLARE_BINARY_OPERATOR_P(operator==, eqmod)
-DECLARE_BINARY_OPERATOR_P(operator!=, neqmod)
 DECLARE_BINARY_OPERATOR_P(operator*, mulmod)
 
 } // nfl

--- a/include/nfl/poly_p.hpp
+++ b/include/nfl/poly_p.hpp
@@ -50,12 +50,16 @@ public:
   poly_type const& poly_obj() const { return *_p; }
 
 public:
-  template <class O>
-  poly_p& operator=(O&& o)
-  {
-    poly_obj() = std::forward<T>(o);
-    return *this;
-  }
+ template <class O>
+ poly_p& operator=(O&& o) {
+   poly_obj() = std::forward<O>(o);
+   return *this;
+ }
+
+ poly_p& operator=(std::initializer_list<T> values) {
+   poly_obj() = std::forward<std::initializer_list<T>>(values);
+   return *this;
+ }
 
   poly_p& operator=(poly_p const& o) 
   {
@@ -125,8 +129,14 @@ public:
 
   value_type& operator()(size_t cm, size_t i) { return poly_obj()(cm, i); }
   value_type const& operator()(size_t cm, size_t i) const { return poly_obj()(cm, i); }
+  template<class M> auto load(size_t cm, size_t i) const -> decltype(M::load(&(this->operator()(cm, i)))) { return M::load(&(*this)(cm, i)); }
 
   static constexpr value_type get_modulus(size_t n) { return poly_type::get_modulus(n); }
+
+  /* ntt stuff - public API
+   */
+  void ntt_pow_phi() { poly_obj().ntt_pow_phi();}
+  void invntt_pow_invphi() { poly_obj().invntt_pow_invphi(); }
 
 private:
   template <class... Args>
@@ -161,6 +171,8 @@ std::ostream& operator<<(std::ostream& os, nfl::poly_p<T, Degree, NbModuli> cons
   return os << p.poly_obj();
 }
 
+/* unary operators
+*/
 template<class E, class T, size_t Degree, size_t NbModuli>
 auto shoup(E const& e, poly_p<T, Degree, NbModuli> const& m) -> decltype(shoup(e, m.poly_obj()))
 {
@@ -172,6 +184,28 @@ auto compute_shoup(poly_p<T, Degree, NbModuli> const& p) -> decltype(compute_sho
 {
   return compute_shoup(p.poly_obj());
 }
+
+/* operator overloads - includes expression templates
+ */
+#define DECLARE_BINARY_OPERATOR_P(SYM, NAME)\
+template<class T, size_t Degree, size_t NbModuli>\
+auto SYM(nfl::poly_p<T, Degree, NbModuli> const& op0, nfl::poly_p<T, Degree, NbModuli> const& op1) -> decltype(ops::make_op<ops::NAME<T, CC_SIMD>>(op0, op1)) {\
+  return ops::make_op<ops::NAME<T, CC_SIMD>>(op0, op1);\
+}\
+template<class T, size_t Degree, size_t NbModuli, class Op, class...Args>\
+auto SYM(nfl::poly_p<T, Degree, NbModuli> const& op0, nfl::ops::expr<Op, Args...> const& op1) -> decltype(ops::make_op<ops::NAME<typename nfl::ops::expr<Op, Args...>::value_type, typename nfl::ops::expr<Op, Args...>::simd_mode>>(op0, op1)) {\
+  return ops::make_op<ops::NAME<typename nfl::ops::expr<Op, Args...>::value_type, typename nfl::ops::expr<Op, Args...>::simd_mode>>(op0, op1);\
+}\
+template<class T, size_t Degree, size_t NbModuli, class Op, class...Args>\
+auto SYM(nfl::ops::expr<Op, Args...> const& op0, nfl::poly_p<T, Degree, NbModuli> const& op1) -> decltype(ops::make_op<ops::NAME<typename nfl::ops::expr<Op, Args...>::value_type, typename nfl::ops::expr<Op, Args...>::simd_mode>>(op0, op1)){\
+  return ops::make_op<ops::NAME<typename nfl::ops::expr<Op, Args...>::value_type, typename nfl::ops::expr<Op, Args...>::simd_mode>>(op0, op1);\
+}
+
+DECLARE_BINARY_OPERATOR_P(operator-, submod)
+DECLARE_BINARY_OPERATOR_P(operator+, addmod)
+DECLARE_BINARY_OPERATOR_P(operator==, eqmod)
+DECLARE_BINARY_OPERATOR_P(operator!=, neqmod)
+DECLARE_BINARY_OPERATOR_P(operator*, mulmod)
 
 } // nfl
 

--- a/tests/poly_p.cpp
+++ b/tests/poly_p.cpp
@@ -2,43 +2,80 @@
 #include <nfl/poly_p.hpp>
 #include "tools.h"
 
-template<size_t degree, size_t modulus, class T>
-bool run()
-{
+template <size_t degree, size_t modulus, class T>
+bool run() {
   using poly_p = nfl::poly_p_from_modulus<T, degree, modulus>;
   using poly_t = nfl::poly_from_modulus<T, degree, modulus>;
 
-  // Test simple addition
+  bool ret = true;
+
+  // Define polynomials
   poly_p a{nfl::uniform()};
   poly_p b{nfl::uniform()};
 
-  poly_t &tmp = *alloc_aligned<poly_t, 32>(1, a.poly_obj()+b.poly_obj());
-  poly_p add_p{a+b};
+  poly_t& A = *alloc_aligned<poly_t, 32>(1, a.poly_obj());
+  poly_t& B = *alloc_aligned<poly_t, 32>(1, b.poly_obj());
 
-  bool ret = true;
-  ret &= (add_p == tmp);
+  // Test addition
+  poly_t& add = *alloc_aligned<poly_t, 32>(1, A + B);
+  poly_p add_p{a + b};
+  ret &= (add_p == add);
+
+  // Test substraction
+  poly_t& sub = *alloc_aligned<poly_t, 32>(1, A - B);
+  poly_p sub_p{a - b};
+  ret &= (sub_p == sub);
+
+  // Test multiplication
+  poly_t& mul = *alloc_aligned<poly_t, 32>(1, A * B);
+  poly_p mul_p{a * b};
+  ret &= (mul_p == mul);
 
   // Test detach
   poly_p c{b};
   ret &= (c == b);
 
+  // Test assign
   c = {1};
   ret &= (c != b);
 
   // Shoup
   poly_p bshoup = nfl::compute_shoup(b);
-  tmp = nfl::compute_shoup(b.poly_obj());
-  ret &= (bshoup == tmp);
+  poly_t& Bshoup = *alloc_aligned<poly_t, 32>(1, nfl::compute_shoup(B));
+  ret &= (bshoup == Bshoup);
 
-  poly_p res = nfl::shoup(a * b, bshoup);
-  tmp = nfl::shoup(a.poly_obj() * b.poly_obj(), bshoup.poly_obj());
-  ret &= (res == tmp);
+  poly_p mul2_p = nfl::shoup(a * b, bshoup);
+  poly_t& mul2 = *alloc_aligned<poly_t, 32>(1, nfl::shoup(A * B, Bshoup));
+  ret &= (mul2_p == mul2);
 
+  // NTT and invNTT
+  a.ntt_pow_phi();
+  A.ntt_pow_phi();
+  ret &= (a == A);
+
+  b.invntt_pow_invphi();
+  B.invntt_pow_invphi();
+  ret &= (b == B);
+
+  // Operators overloads with expression templates
+  // (test == operator in both directions: poly_p == poly_t
+  // and poly_t == poly_p)
+  poly_p tmp_p = a + b * add_p;
+  ret &= (tmp_p == A + B * add);
+  poly_t& tmp = *alloc_aligned<poly_t, 32>(1, A + B * add);
+  ret &= (tmp == a + b * add_p);
+
+  // Cleaning
+  free_aligned(1, &add);
+  free_aligned(1, &sub);
+  free_aligned(1, &mul);
+  free_aligned(1, &mul2);
+  free_aligned(1, &Bshoup);
   free_aligned(1, &tmp);
 
   return ret;
 }
 
 int main(int argc, char const* argv[]) {
-  return not run<CONFIG>() ;
+  return not run<CONFIG>();
 }


### PR DESCRIPTION
poly_p was missing several functions, such as ntt_pow_phi & invntt_pow_invphi, and operator overloads using expression templates.