### PR TITLE
Add missing namespace nfl to FastGaussianNoise & aligned_allocator

### DIFF
--- a/include/nfl/aligned_allocator.hpp
+++ b/include/nfl/aligned_allocator.hpp
@@ -6,6 +6,8 @@
  * http://jmabille.github.io/blog/2014/12/06/aligned-memory-allocator/
  */
 
+namespace nfl {
+
 namespace detail {
 inline void* _aligned_malloc(size_t size, size_t alignment) {
   void* res = 0;
@@ -114,4 +116,6 @@ typename aligned_allocator<T, N>::pointer aligned_allocator<T, N>::allocate(
 template <class T, int N>
 inline void aligned_allocator<T, N>::deallocate(pointer p, size_type) {
   aligned_free(p);
+}
+
 }

--- a/include/nfl/prng/FastGaussianNoise.hpp
+++ b/include/nfl/prng/FastGaussianNoise.hpp
@@ -1,9 +1,6 @@
 #ifndef fast_gauss_noise_h
 #define fast_gauss_noise_h
 
-#define tstbit(x, n)  ((x << (63 - n)) >> 63 )
-
-
 #include <cstdint>
 #include <cstddef>
 #include <list>
@@ -22,6 +19,10 @@
 #ifdef BOOST_RAPHSON
 #include <boost/math/tools/roots.hpp>
 #endif
+
+namespace nfl {
+
+#define tstbit(x, n)  ((x << (63 - n)) >> 63 )
 
 //#define OUTPUT_BARRIERS
 //#define OUTPUT_LUT_FLAGS
@@ -645,6 +646,6 @@ FastGaussianNoise<in_class, out_class, _lu_depth>::~FastGaussianNoise()
   }
 }
 
-
+}  // namespace nfl
 
 #endif

--- a/include/nfl/prng/FastGaussianNoise.hpp
+++ b/include/nfl/prng/FastGaussianNoise.hpp
@@ -20,14 +20,16 @@
 #include <boost/math/tools/roots.hpp>
 #endif
 
-namespace nfl {
-
-#define tstbit(x, n)  ((x << (63 - n)) >> 63 )
 
 //#define OUTPUT_BARRIERS
 //#define OUTPUT_LUT_FLAGS
 // Use it to test rare values do not happen too often
 //#define UNITTEST_ONEMILLION
+
+namespace nfl {
+
+template<typename T0, typename T1>
+constexpr inline auto tstbit(T0 x, T1 n) -> decltype((x << (63 - n)) >> 63 ) { return ((x << (63 - n)) >> 63 ); }
 
 template<class in_class, class out_class>
 struct output {
@@ -276,7 +278,7 @@ void FastGaussianNoise<in_class, out_class, _lu_depth>::init()
     std::cout << "FastGaussianNoise: WARNING outputs are above 2**31, unexpected results" << std::endl;
 
   // Finally we precompute 1/(2*sigma**2) to accelerate things
-	mpfr_inits2(_bit_precision, _const_sigma, NULL);
+	mpfr_inits2(_bit_precision, _const_sigma, nullptr);
   mpfr_set_d(_const_sigma, _sigma, MPFR_RNDN);
 	mpfr_sqr(_const_sigma, _const_sigma, MPFR_RNDN);
 	mpfr_mul_ui(_const_sigma, _const_sigma, 2, MPFR_RNDN); 
@@ -295,7 +297,7 @@ void FastGaussianNoise<in_class, out_class, _lu_depth>::precomputeBarrierValues(
   // Declare and init mpfr vars
   mpfr_t sum, tmp, tmp2;
   mpfr_t *mp_barriers;
-  mpfr_inits2(_bit_precision, sum, tmp, tmp2, NULL);
+  mpfr_inits2(_bit_precision, sum, tmp, tmp2, nullptr);
 
   // This var is used to export mpfr values
   mpz_t int_value;
@@ -346,7 +348,7 @@ void FastGaussianNoise<in_class, out_class, _lu_depth>::precomputeBarrierValues(
     mpfr_mul(mp_barriers[i], mp_barriers[i], sum, MPFR_RNDN);  
     mpfr_get_z(int_value, mp_barriers[i], MPFR_RNDN);
     mpz_export((void *) (barriers[i] + ((int)_word_precision - 
-           (int)ceil( (float)mpz_sizeinbase(int_value, 256)/sizeof(in_class) ))), NULL, 1, sizeof(in_class), 0, 0, int_value);
+           (int)ceil( (float)mpz_sizeinbase(int_value, 256)/sizeof(in_class) ))), nullptr, 1, sizeof(in_class), 0, 0, int_value);
 #ifdef OUTPUT_BARRIERS
     mpz_out_str(stdout, 10, int_value);
     std::cout << " = Barriers[" << i << "] = " << std::endl;
@@ -358,7 +360,7 @@ void FastGaussianNoise<in_class, out_class, _lu_depth>::precomputeBarrierValues(
 #endif 
     mpfr_clear(mp_barriers[i]);
   }
-	mpfr_clears(sum, tmp, tmp2, NULL);
+	mpfr_clears(sum, tmp, tmp2, nullptr);
   mpz_clear(int_value);
 	mpfr_free_cache();
   free(mp_barriers);
@@ -626,11 +628,11 @@ FastGaussianNoise<in_class, out_class, _lu_depth>::~FastGaussianNoise()
   // Freed allocated memory for the barriers
   for (unsigned ctr = 0; ctr < _number_of_barriers; ctr++)
   {
-    if (barriers[ctr] != NULL) free(barriers[ctr]); 
-    barriers[ctr] = NULL;
+    if (barriers[ctr] != nullptr) free(barriers[ctr]); 
+    barriers[ctr] = nullptr;
   }
-  if (barriers != NULL) free(barriers);
-  barriers=NULL;
+  if (barriers != nullptr) free(barriers);
+  barriers=nullptr;
 
   // Free other variables
   mpfr_clear(_const_sigma);
@@ -640,7 +642,7 @@ FastGaussianNoise<in_class, out_class, _lu_depth>::~FastGaussianNoise()
   {
     for (unsigned ctr = 0 ; ctr < _lu_size; ctr++)
     {
-      if (lu_table2[ctr]!=NULL) delete[](lu_table2[ctr]);
+      if (lu_table2[ctr]!=nullptr) delete[](lu_table2[ctr]);
     }
     free(lu_table2);
   }

--- a/include/nfl/prng/crypto_stream_salsa20.h
+++ b/include/nfl/prng/crypto_stream_salsa20.h
@@ -1,30 +1,12 @@
 #ifndef CRYPTO_STREAM_H
 #define CRYPTO_STREAM_H
 
-#ifdef __cplusplus
 #include <string>
-#endif
 
-namespace nfl
-{
-#define crypto_stream_salsa20_KEYBYTES 32
-#define crypto_stream_salsa20_NONCEBYTES 8
-
-#ifdef __cplusplus
 extern "C" {
-#endif
-extern
-int crypto_stream_salsa20_amd64_xmm6(
-        unsigned char *c,unsigned long long clen,
-  const unsigned char *n,
-  const unsigned char *k
-);
-    
-#ifdef __cplusplus
-}
-#endif
-#define crypto_stream_salsa20 crypto_stream_salsa20_amd64_xmm6
-
+int nfl_crypto_stream_salsa20_amd64_xmm6(unsigned char *c, unsigned long long clen,
+                                     const unsigned char *n,
+                                     const unsigned char *k);
 }
 
 #endif

--- a/include/nfl/prng/crypto_stream_salsa20.h
+++ b/include/nfl/prng/crypto_stream_salsa20.h
@@ -1,11 +1,16 @@
 #ifndef CRYPTO_STREAM_H
 #define CRYPTO_STREAM_H
 
+#ifdef __cplusplus
+#include <string>
+#endif
+
+namespace nfl
+{
 #define crypto_stream_salsa20_KEYBYTES 32
 #define crypto_stream_salsa20_NONCEBYTES 8
 
 #ifdef __cplusplus
-#include <string>
 extern "C" {
 #endif
 extern
@@ -19,5 +24,7 @@ int crypto_stream_salsa20_amd64_xmm6(
 }
 #endif
 #define crypto_stream_salsa20 crypto_stream_salsa20_amd64_xmm6
+
+}
 
 #endif

--- a/include/nfl/prng/fastrandombytes.h
+++ b/include/nfl/prng/fastrandombytes.h
@@ -7,6 +7,8 @@
 #ifndef FASTRANDOMBYTES_H
 #define FASTRANDOMBYTES_H
 
+namespace nfl {
 void fastrandombytes(unsigned char *r, unsigned long long rlen);
+}
 
 #endif

--- a/include/nfl/prng/randombytes.h
+++ b/include/nfl/prng/randombytes.h
@@ -7,6 +7,8 @@ Public domain.
 #ifndef RANDOMBYTES_H
 #define RANDOMBYTES_H
 
-void randombytes(unsigned char *,unsigned long long);
+namespace nfl {
+void randombytes(unsigned char *, unsigned long long);
+}
 
 #endif

--- a/lib/prng/fastrandombytes.cpp
+++ b/lib/prng/fastrandombytes.cpp
@@ -4,35 +4,29 @@
  * Public Domain
  */
 
-#include "nfl/prng/crypto_stream_salsa20.h"
-#include "nfl/prng/randombytes.h"
 #include <inttypes.h>
 #include <iostream>
+#include "nfl/prng/crypto_stream_salsa20.h"
+#include "nfl/prng/randombytes.h"
 
 namespace nfl {
 
 static int init = 0;
-static unsigned char key[crypto_stream_salsa20_KEYBYTES];
-static unsigned char nonce[crypto_stream_salsa20_NONCEBYTES] = {0};
+static unsigned char key[32];
+static unsigned char nonce[8] = {0};
 
-void fastrandombytes(unsigned char *r, unsigned long long rlen)
-{
-  unsigned long long n=0;
+void fastrandombytes(unsigned char *r, unsigned long long rlen) {
+  unsigned long long n = 0;
   int i;
-  if(!init)
-  {
-    randombytes(key, crypto_stream_salsa20_KEYBYTES);
+  if (!init) {
+    randombytes(key, 32);
     init = 1;
   }
-  //crypto_stream(r,rlen,nonce,key);
-  crypto_stream_salsa20(r,rlen,nonce,key);
+  nfl_crypto_stream_salsa20_amd64_xmm6(r, rlen, nonce, key);
 
   // Increase 64-bit counter (nonce)
-  for(i=0;i<8;i++)
-    n ^= ((unsigned long long)nonce[i]) << 8*i;
+  for (i = 0; i < 8; i++) n ^= ((unsigned long long)nonce[i]) << 8 * i;
   n++;
-  for(i=0;i<8;i++)
-    nonce[i] = (n >> 8*i) & 0xff;
+  for (i = 0; i < 8; i++) nonce[i] = (n >> 8 * i) & 0xff;
 }
-
 }

--- a/lib/prng/fastrandombytes.cpp
+++ b/lib/prng/fastrandombytes.cpp
@@ -9,24 +9,27 @@
 #include "nfl/prng/crypto_stream_salsa20.h"
 #include "nfl/prng/randombytes.h"
 
+#define nfl_crypto_stream_salsa20_KEYBYTES 32
+#define nfl_crypto_stream_salsa20_NONCEBYTES 8
+
 namespace nfl {
 
 static int init = 0;
-static unsigned char key[32];
-static unsigned char nonce[8] = {0};
+static unsigned char key[nfl_crypto_stream_salsa20_KEYBYTES];
+static unsigned char nonce[nfl_crypto_stream_salsa20_NONCEBYTES] = {0};
 
 void fastrandombytes(unsigned char *r, unsigned long long rlen) {
   unsigned long long n = 0;
   int i;
   if (!init) {
-    randombytes(key, 32);
+    randombytes(key, nfl_crypto_stream_salsa20_KEYBYTES);
     init = 1;
   }
   nfl_crypto_stream_salsa20_amd64_xmm6(r, rlen, nonce, key);
 
   // Increase 64-bit counter (nonce)
-  for (i = 0; i < 8; i++) n ^= ((unsigned long long)nonce[i]) << 8 * i;
+  for (i = 0; i < nfl_crypto_stream_salsa20_NONCEBYTES; i++) n ^= ((unsigned long long)nonce[i]) << 8 * i;
   n++;
-  for (i = 0; i < 8; i++) nonce[i] = (n >> 8 * i) & 0xff;
+  for (i = 0; i < nfl_crypto_stream_salsa20_NONCEBYTES; i++) nonce[i] = (n >> 8 * i) & 0xff;
 }
 }

--- a/lib/prng/fastrandombytes.cpp
+++ b/lib/prng/fastrandombytes.cpp
@@ -9,6 +9,8 @@
 #include <inttypes.h>
 #include <iostream>
 
+namespace nfl {
+
 static int init = 0;
 static unsigned char key[crypto_stream_salsa20_KEYBYTES];
 static unsigned char nonce[crypto_stream_salsa20_NONCEBYTES] = {0};
@@ -33,15 +35,4 @@ void fastrandombytes(unsigned char *r, unsigned long long rlen)
     nonce[i] = (n >> 8*i) & 0xff;
 }
 
-/*int main(int argc, char**argv) {
-    int randlen = 1024;
-    unsigned char t[randlen*sizeof(unsigned long long)];
-    double start = omp_get_wtime();
-    fastrandombytes((unsigned char *)t, randlen*sizeof(unsigned long long));
-    double end= omp_get_wtime();
-    std::cout << (end-start) << std::endl;
-    for(int i=0;i<1024*sizeof(unsigned long long);i++) std::cout<<std::hex<<(int)t[i]<<" ";
-    std::cout<<std::endl;
-    
-    
-}*/
+}

--- a/lib/prng/fastrandombytes.cpp
+++ b/lib/prng/fastrandombytes.cpp
@@ -9,27 +9,27 @@
 #include "nfl/prng/crypto_stream_salsa20.h"
 #include "nfl/prng/randombytes.h"
 
-#define nfl_crypto_stream_salsa20_KEYBYTES 32
-#define nfl_crypto_stream_salsa20_NONCEBYTES 8
-
 namespace nfl {
 
+static size_t constexpr crypto_stream_salsa20_KEYBYTES = 32;
+static size_t constexpr crypto_stream_salsa20_NONCEBYTES = 8;
+
 static int init = 0;
-static unsigned char key[nfl_crypto_stream_salsa20_KEYBYTES];
-static unsigned char nonce[nfl_crypto_stream_salsa20_NONCEBYTES] = {0};
+static unsigned char key[crypto_stream_salsa20_KEYBYTES];
+static unsigned char nonce[crypto_stream_salsa20_NONCEBYTES] = {0};
 
 void fastrandombytes(unsigned char *r, unsigned long long rlen) {
   unsigned long long n = 0;
   int i;
   if (!init) {
-    randombytes(key, nfl_crypto_stream_salsa20_KEYBYTES);
+    randombytes(key, crypto_stream_salsa20_KEYBYTES);
     init = 1;
   }
   nfl_crypto_stream_salsa20_amd64_xmm6(r, rlen, nonce, key);
 
   // Increase 64-bit counter (nonce)
-  for (i = 0; i < nfl_crypto_stream_salsa20_NONCEBYTES; i++) n ^= ((unsigned long long)nonce[i]) << 8 * i;
+  for (i = 0; i < crypto_stream_salsa20_NONCEBYTES; i++) n ^= ((unsigned long long)nonce[i]) << 8 * i;
   n++;
-  for (i = 0; i < nfl_crypto_stream_salsa20_NONCEBYTES; i++) nonce[i] = (n >> 8 * i) & 0xff;
+  for (i = 0; i < crypto_stream_salsa20_NONCEBYTES; i++) nonce[i] = (n >> 8 * i) & 0xff;
 }
 }

--- a/lib/prng/nfl_crypto_stream_salsa20_amd64_xmm6.s
+++ b/lib/prng/nfl_crypto_stream_salsa20_amd64_xmm6.s
@@ -333,13 +333,13 @@
 
 # qhasm: stack64 bytes_backup
 
-# qhasm: enter crypto_stream_salsa20_amd64_xmm6
+# qhasm: enter nfl_crypto_stream_salsa20_amd64_xmm6
 .text
 .p2align 5
-.globl _crypto_stream_salsa20_amd64_xmm6
-.globl crypto_stream_salsa20_amd64_xmm6
-_crypto_stream_salsa20_amd64_xmm6:
-crypto_stream_salsa20_amd64_xmm6:
+.globl _nfl_crypto_stream_salsa20_amd64_xmm6
+.globl nfl_crypto_stream_salsa20_amd64_xmm6
+_nfl_crypto_stream_salsa20_amd64_xmm6:
+nfl_crypto_stream_salsa20_amd64_xmm6:
 mov %rsp,%r11
 and $31,%r11
 add $480,%r11
@@ -436,13 +436,13 @@ sub  %r9,%rdi
 # qhasm: goto start
 jmp ._start
 
-# qhasm: enter crypto_stream_salsa20_amd64_xmm6_xor
+# qhasm: enter nfl_crypto_stream_salsa20_amd64_xmm6_xor
 .text
 .p2align 5
-.globl _crypto_stream_salsa20_amd64_xmm6_xor
-.globl crypto_stream_salsa20_amd64_xmm6_xor
-_crypto_stream_salsa20_amd64_xmm6_xor:
-crypto_stream_salsa20_amd64_xmm6_xor:
+.globl _nfl_crypto_stream_salsa20_amd64_xmm6_xor
+.globl nfl_crypto_stream_salsa20_amd64_xmm6_xor
+_nfl_crypto_stream_salsa20_amd64_xmm6_xor:
+nfl_crypto_stream_salsa20_amd64_xmm6_xor:
 mov %rsp,%r11
 and $31,%r11
 add $480,%r11

--- a/lib/prng/randombytes.cpp
+++ b/lib/prng/randombytes.cpp
@@ -4,6 +4,8 @@
 #include <unistd.h>
 #include "randombytes.h"
 
+namespace nfl {
+
 /* it's really stupid that there isn't a syscall for this */
 
 static int fd = -1;
@@ -32,4 +34,6 @@ void randombytes(unsigned char *x,unsigned long long xlen)
     x += i;
     xlen -= i;
   }
+}
+
 }

--- a/lib/prng/randombytes.cpp
+++ b/lib/prng/randombytes.cpp
@@ -1,31 +1,28 @@
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include "randombytes.h"
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace nfl {
 
-/* it's really stupid that there isn't a syscall for this */
-
 static int fd = -1;
 
-void randombytes(unsigned char *x,unsigned long long xlen)
-{
+void randombytes(unsigned char *x, unsigned long long xlen) {
   int i;
 
   if (fd == -1) {
     for (;;) {
-      fd = open("/dev/urandom",O_RDONLY);
+      fd = open("/dev/urandom", O_RDONLY);
       if (fd != -1) break;
       sleep(1);
     }
   }
 
   while (xlen > 0) {
-    if (xlen < 1048576) i = xlen; else i = 1048576;
+    i = (xlen < 1048576) ? xlen : 1048576;
+    i = read(fd, x, i);
 
-    i = read(fd,x,i);
     if (i < 1) {
       sleep(1);
       continue;
@@ -35,5 +32,4 @@ void randombytes(unsigned char *x,unsigned long long xlen)
     xlen -= i;
   }
 }
-
 }

--- a/tests/nfllib_demo_main_op.cpp
+++ b/tests/nfllib_demo_main_op.cpp
@@ -23,7 +23,7 @@
 #define TEST_LWE_SYMMETRIC
 
 template <class P>
-__attribute__((noinline)) static void encrypt(P& resa, P& resb, P const & pka, P const & pkb, P const & pkaprime, P const & pkbprime, FastGaussianNoise<uint8_t, typename P::value_type, 2> *g_prng)
+__attribute__((noinline)) static void encrypt(P& resa, P& resb, P const & pka, P const & pkb, P const & pkaprime, P const & pkbprime, nfl::FastGaussianNoise<uint8_t, typename P::value_type, 2> *g_prng)
 {
   // u
   P tmpu = nfl::gaussian<uint8_t, typename P::value_type, 2>(g_prng);
@@ -163,7 +163,7 @@ int run()
 #endif
 
 #ifdef TEST_GAUSSIAN_GENERATION
-  FastGaussianNoise<uint8_t, T, 2> fg_prng(20, 128, 1<<14);
+  nfl::FastGaussianNoise<uint8_t, T, 2> fg_prng(20, 128, 1<<14);
   start = std::chrono::steady_clock::now();
   std::fill(resa, resa + REPETITIONS, nfl::gaussian<uint8_t, T, 2>(&fg_prng));
   std::fill(resb, resb + REPETITIONS, nfl::gaussian<uint8_t, T, 2>(&fg_prng));
@@ -294,17 +294,12 @@ int run()
 	  &pkb = *alloc_aligned<poly_t, 32>(1),
 	  &pkbprime = *alloc_aligned<poly_t, 32>(1);
   
+  // Gaussian sampler
+  nfl::FastGaussianNoise<uint8_t, T, 2> g_prng(SIGMA, 128, 1<<10);
+  
   // This step generates a secret key
-  FastGaussianNoise<uint8_t, T, 2> g_prng(SIGMA, 128, 1<<10);
-  // BUG CRASHES
-  //FastGaussianNoise<uint8_t, T, 2> g_prng(SIGMA, 80, 1<<8);
   poly_t &s = *alloc_aligned<poly_t, 32>(1, nfl::gaussian<uint8_t, T, 2>(&g_prng));
   poly_t &sprime = *alloc_aligned<poly_t, 32>(1);
-  //for(auto & v : s)
-  //{
-  //  std::cout <<  v << " ";
-  //}
-  std::cout << std::endl;
   s.ntt_pow_phi();
   sprime = nfl::compute_shoup(s);
 

--- a/tests/prng_demo_main.cpp
+++ b/tests/prng_demo_main.cpp
@@ -7,16 +7,16 @@ int main(int argc, const char *argv[])
 {
 	typedef int32_t T;
 	//FastGaussianNoise<uint16_t, T, 1> rng(300, 128, 1UL<<10, true);
-	FastGaussianNoise<uint8_t, T, 2> rng(3.19, 128, 1UL << 19, 5.25, true);
+	nfl::FastGaussianNoise<uint8_t, T, 2> rng(3.19, 128, 1UL << 19, 5.25, true);
 
 	T *noise = new T[OUTPUT_NOISE_SIZE]();
 	bzero(noise, OUTPUT_NOISE_SIZE);
 
 	for (unsigned i = 0; i < REPETITIONS ; i++)
 	{
-		uint64_t start = rdtsc();
+		uint64_t start = nfl::rdtsc();
 		rng.getNoise(noise, OUTPUT_NOISE_SIZE);
-		uint64_t stop = rdtsc();
+		uint64_t stop = nfl::rdtsc();
 
 	  printf("FastGaussianNoise: Gaussian noise cycles = %.2e bits = %.2e cycles/bit = %.2e\n", (float) stop - start, (float) (OUTPUT_NOISE_SIZE*CHAR_BIT), (float)(stop - start) / (OUTPUT_NOISE_SIZE*CHAR_BIT));
   } 


### PR DESCRIPTION
The FastGaussianNoise class and other random generation functions were not encapsulated in the nfl namespace.

I did some minimal cleanup also.