### PR TITLE
Update extension name

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,7 +29,7 @@ import os
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Solve the warning when using sphinx.
`WARNING: sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.`