### PR TITLE
GCC cannot link AVX code on OSX. This patch tells GCC to use LLVM as the linker.

### DIFF
--- a/CMakeCompilers.txt
+++ b/CMakeCompilers.txt
@@ -27,3 +27,8 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 endif()
 
+if(APPLE)
+   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wa,-q")
+endif()
+
+


### PR DESCRIPTION
So the 3 added lines check if we are running on OSX (... actually Apple) and if so adds the options to tell GCC to use llvm.