### PR TITLE
hamming weight distribution

### DIFF
--- a/include/nfl/core.hpp
+++ b/include/nfl/core.hpp
@@ -2,6 +2,9 @@
 #define NFL_CORE_HPP
 
 #include <type_traits>
+#include <vector>
+#include <numeric>
+#include <algorithm>
 
 #include "nfl/poly.hpp"
 #include "nfl/ops.hpp"
@@ -322,6 +325,44 @@ void poly<T, Degree, NbModuli>::set(gaussian<in_class, T, _lu_depth> const& mode
 #endif
 }
 
+template<class T, size_t Degree, size_t NbModuli>
+poly<T, Degree, NbModuli>::poly(hwt_dist const& mode) {
+  set(mode);
+}
+
+template<class T, size_t Degree, size_t NbModuli>
+void poly<T, Degree, NbModuli>::set(hwt_dist const& mode) {
+  assert(mode.hwt <= Degree);
+  std::vector<size_t> hitted(mode.hwt);
+  std::iota(hitted.begin(), hitted.end(), 0U); // select the first hwt positions.
+
+  size_t rnd[128];
+  size_t *rnd_end = rnd + 128;
+  size_t *rnd_ptr = rnd_end;
+  for (size_t k = mode.hwt; k < degree; ++k) 
+  {
+    if (rnd_ptr == rnd_end)
+    {
+      fastrandombytes((unsigned char *)rnd, sizeof(rnd));
+      rnd_ptr = &rnd[0];
+    }
+    size_t pos = (*rnd_ptr++) % k;
+    if (pos < mode.hwt)
+      hitted[pos] = k;
+  }
+
+  std::sort(hitted.begin(), hitted.end()); // for better locality ?
+  std::memset(_data, 0x0, N * sizeof(value_type)); // clear up all
+  size_t offset = 0;
+  while (offset < N) 
+  {
+    for (size_t pos : hitted)
+      _data[pos + offset] = 1U;
+    offset += degree;
+  }
+  std::memset(hitted.data(), 0x0, hitted.size() * sizeof(size_t)); // erase from memory
+  std::memset(rnd, 0x0, sizeof(rnd)); // erase from memory
+}
 
 // *********************************************************
 // Helper functions

--- a/include/nfl/poly.hpp
+++ b/include/nfl/poly.hpp
@@ -48,6 +48,11 @@ struct non_uniform {
   non_uniform(uint64_t ub, uint64_t amp) : upper_bound{ub}, amplifier{amp} {}
 };
 
+struct hwt_dist { // hamming weight distribution.
+  uint32_t hwt;
+  hwt_dist(uint32_t hwt_) : hwt(hwt_) {}
+};
+
 template<class in_class, class out_class, unsigned _lu_depth>
 struct gaussian {
   FastGaussianNoise<in_class, out_class, _lu_depth> *fg_prng;
@@ -99,6 +104,7 @@ public:
   poly();
   poly(uniform const& mode);
   poly(non_uniform const& mode);
+  poly(hwt_dist const& mode);
   poly(value_type v, bool reduce_coeffs = true);
   poly(std::initializer_list<value_type> values, bool reduce_coeffs = true);
   template <class It> poly(It first, It last, bool reduce_coeffs = true);
@@ -107,6 +113,7 @@ public:
 
   void set(uniform const& mode);
   void set(non_uniform const& mode);
+  void set(hwt_dist const& mode);
   void set(value_type v, bool reduce_coeffs = true);
   void set(std::initializer_list<value_type> values, bool reduce_coeffs = true);
   template <class It> void set(It first, It last, bool reduce_coeffs = true);
@@ -117,6 +124,7 @@ public:
   poly& operator=(value_type v) { set(v); return *this; }
   poly& operator=(uniform const& mode) { set(mode); return *this; }
   poly& operator=(non_uniform const& mode) { set(mode); return *this; }
+  poly& operator=(hwt_dist const& mode) { set(mode); return *this; }
   poly& operator=(std::initializer_list<value_type> values) { set(values); return *this; }
   template <class in_class, unsigned _lu_depth> poly& operator=(gaussian<in_class, T, _lu_depth> const& mode) { set(mode); return *this; }
   template <class Op, class... Args> poly& operator=(ops::expr<Op, Args...> const& expr);


### PR DESCRIPTION
* HWT distribution is usually used in sampling small norm of secret key.
* Use the reservoir sampling to equally select K positions from N positions.