### PR TITLE
Fixed bug in sub testing code

### DIFF
--- a/tests/nfl_sub.cpp
+++ b/tests/nfl_sub.cpp
@@ -9,7 +9,7 @@ bool test_op()
   using greater_value_type = typename P::greater_value_type;
 
   return test_binary_op<P>(
-      [](T a, T b, T m) { return (a-b) % m; },
+      [](T a, T b, T m) { return (a >= b) ? (a-b) : (a-b+m); },
       [](P const& a, P const& b) { return a-b; }
   );
 }


### PR DESCRIPTION
Library failed subtraction test when compiled with AVX optimizations. It turns out the bug was in the test code, due to computation of a-b using unsigned integer arithmetic. Fixed the bug in the test code.