### PR TITLE
replace 1 million degree poly in stack with 32k poly

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CONFIGS
     "128, 14, uint16_t"
     "1024, 60, uint32_t"
     "8192, 124, uint64_t"
-    "1048576, 124, uint64_t"
+    "32768, 124, uint64_t"
 )
 
 #always double check during tests


### PR DESCRIPTION
This PR should solve a few issues. I just replaced the huge tests done as almost nobody uses polynomials of degree 1 Million and if so he will place them in the heap not in the stack as our tests do.

Without comments I will self accept this in a few days.

Fixes #34 #20.
